### PR TITLE
Add JWT request filter

### DIFF
--- a/src/main/java/me/cryptforge/mindset/security/JwtAuthenticationEntryEndpoint.java
+++ b/src/main/java/me/cryptforge/mindset/security/JwtAuthenticationEntryEndpoint.java
@@ -1,0 +1,20 @@
+package me.cryptforge.mindset.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryEndpoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+    }
+
+}

--- a/src/main/java/me/cryptforge/mindset/security/JwtRequestFilter.java
+++ b/src/main/java/me/cryptforge/mindset/security/JwtRequestFilter.java
@@ -1,0 +1,64 @@
+package me.cryptforge.mindset.security;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import me.cryptforge.mindset.service.EntityUserDetailsService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtRequestFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private EntityUserDetailsService userDetailsService;
+
+    @Autowired
+    private JwtTokenUtil tokenUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        final String token = parseToken(request);
+
+        try {
+            if (token != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                final String username = tokenUtil.getUsernameFromToken(token);
+                final UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+                if (tokenUtil.validateToken(token, userDetails)) {
+                    final var authenticationToken = new UsernamePasswordAuthenticationToken(
+                            userDetails,
+                            null,
+                            userDetails.getAuthorities()
+                    );
+                    authenticationToken.setDetails(new WebAuthenticationDetailsSource()
+                            .buildDetails(request)
+                    );
+
+                    SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+                }
+            }
+        } catch (ExpiredJwtException ignored) {
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String parseToken(HttpServletRequest request) {
+        final String header = request.getHeader("Authorization");
+        if (StringUtils.hasText(header) && header.startsWith("Bearer ")) {
+            return header.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/me/cryptforge/mindset/service/AuthServiceImpl.java
+++ b/src/main/java/me/cryptforge/mindset/service/AuthServiceImpl.java
@@ -2,6 +2,8 @@ package me.cryptforge.mindset.service;
 
 import me.cryptforge.mindset.dto.auth.LoginRequest;
 import me.cryptforge.mindset.dto.auth.LoginResponse;
+import me.cryptforge.mindset.model.user.User;
+import me.cryptforge.mindset.repository.UserRepository;
 import me.cryptforge.mindset.security.JwtTokenUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +16,9 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class AuthServiceImpl implements AuthService {
+
+    @Autowired
+    UserRepository userRepository;
 
     @Autowired
     AuthenticationManager authenticationManager;
@@ -34,13 +39,14 @@ public class AuthServiceImpl implements AuthService {
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         final UserDetails userDetails = userDetailsService.loadUserByUsername(request.email());
+        final User user = userRepository.findByEmail(request.email()).orElseThrow();
 
         final String token = tokenUtil.generateToken(userDetails);
 
         return ResponseEntity.accepted().body(new LoginResponse(
                 token,
                 userDetails.getUsername(),
-                "TRAINEE"
+                user.getRole().name()
         ));
     }
 }


### PR DESCRIPTION
Adds a filter that only allows authorized requests.

Only missing security features are:
 - Endpoint for logging out ("/api/auth/logout")
 - Endpoint for signing up ("/api/auth/signup")